### PR TITLE
Update themes.php

### DIFF
--- a/admin/pages/themes.php
+++ b/admin/pages/themes.php
@@ -82,7 +82,7 @@ if( ! WPF()->usergroup->can( 'mth' ) ) exit;
 							}
 						} else {
 							?>
-                            <div class="wpf-layout-info"><p style="text-align:center;"><? _e( 'No layout found', 'wpforo' ); ?></p></div><?php
+                            <div class="wpf-layout-info"><p style="text-align:center;"><?php _e( 'No layout found', 'wpforo' ); ?></p></div><?php
 						}
 						?>
                     </div>


### PR DESCRIPTION
Remove PHP short tag
As short tags can be disabled it is recommended to only use the normal tags (<?php ?> and <?= ?>) to maximise compatibility.